### PR TITLE
correct filter panel logic and edit styles

### DIFF
--- a/client/src/components/filters/FilterPanel.stories.tsx
+++ b/client/src/components/filters/FilterPanel.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import FilterPanel from './FilterPanel';
-import plankStyles from './FilterPlank.module.scss';
+import './FilterPanel.module.scss';
 import FilterPlank from './FilterPlank';
+import plankStyles from './FilterPlank.module.scss';
 import FilterList from './FilterList';
+import './FilterList.module.scss';
 import FilterRange from './FilterRange';
+import './FilterRange.module.scss';
 import FilterSearch from './FilterSearch';
+import './FilterSearch.module.scss';
 import { genres, countries } from './temp/items';
 import rating from '../../../public/icons/rating.svg';
 import rank from '../../../public/icons/userRank.svg';

--- a/client/src/components/filters/FilterPlank.module.scss
+++ b/client/src/components/filters/FilterPlank.module.scss
@@ -89,8 +89,7 @@
         box-shadow: 0 16px 32px rgba(7, 5, 14, 0.4);
 
         &_countries {
-            //left: -90%;
-            transform: translateX(-31.7%);
+            transform: translateX(-29.8%);
         }
 
         &_genres,

--- a/client/src/components/filters/FilterPlank.tsx
+++ b/client/src/components/filters/FilterPlank.tsx
@@ -7,6 +7,9 @@ const useClickOutside = (handler: () => void) => {
     useEffect(() => {
         const checkClickedTarget = (e: MouseEvent) => {
             const target = e.target as HTMLDivElement;
+            if (target.closest(`.${styles.container__plank_isActive}`)) {
+                return;
+            }
             if (!domNode.current!.contains(target)) {
                 handler();
             }
@@ -31,12 +34,12 @@ const FilterPlank = ({ title, className, children }: IPlank) => {
     const domNode = useClickOutside(() => setIsDropdownShown(false));
 
     return (
-        <div className={styles.container} onClick={() => setIsDropdownShown(!isDropdownShown)}>
+        <div className={styles.container}>
             <div
                 className={[styles.container__plank, isDropdownShown ? styles.container__plank_isActive : null].join(
                     ' ',
                 )}
-                onClick={() => setIsDropdownShown(false)}
+                onClick={() => setIsDropdownShown(!isDropdownShown)}
             >
                 <div className={styles.container__plankContent}>
                     <div className={styles.container__textWrapper}>

--- a/client/src/components/filters/theme.module.scss
+++ b/client/src/components/filters/theme.module.scss
@@ -24,7 +24,6 @@
     color: #fff;
 
     &::placeholder {
-        padding-left: 5px;
         font-size: 12px;
         color: rgba(255, 255, 255, 0.48);
     }
@@ -33,7 +32,7 @@
 .inputFocused {
     &::placeholder {
         font-size: 8px;
-        transform: translateX(-5px) translateY(-15px);
+        transform: translateY(-15px);
         transition-duration: 0.4s;
     }
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -68,6 +68,9 @@ function HomePage() {
                 <FilterPlank title="Актер" className={plankStyles.container__dropdown_narrow}>
                     <FilterSearch searchBy="Актер" />
                 </FilterPlank>
+                <FilterPlank title="Режиссер" className={plankStyles.container__dropdown_narrow}>
+                    <FilterSearch searchBy="Режиссер" />
+                </FilterPlank>
             </MainContainer>
         </>
     );


### PR DESCRIPTION
1) Исправил баг с невозможностью закрыть дропдаун-меню по повторному клику на плашке фильтра.
2) Поправил стили для FilterPlank.
3) Наряду с исправлением стилей также отрефакторил компонент FilterPlank. Теперь проп classname опционален и нужен по сути, когда необходимо сделать дропдаун широким за счет модификаторов leftPositioned (дропдаун спозиционирован левым краем от левого края самой плашки) / centerPositioned (дропдаун спозиционирован по центру). Без переданного класса ширина дропдауна равна ширине плашки.
4) Поправил передаваемые пропсы в файле index страницы movies. Теперь панель фильтров выглядит так, как подразумевалась.. 